### PR TITLE
feat: check whether nested types implement a Marshaler interface

### DIFF
--- a/testdata/src/tests/tests.go
+++ b/testdata/src/tests/tests.go
@@ -130,3 +130,22 @@ func shouldBeIgnored() {
 	json.Marshal(0)   // a non-struct argument.
 	json.Marshal(nil) // nil argument, see issue #20.
 }
+
+type WithInterface struct {
+	NoTag string
+}
+
+func (w WithInterface) MarshalJSON() ([]byte, error) {
+	return json.Marshal(w.NoTag)
+}
+
+func nestedTypeWithInterface() {
+	type Foo struct {
+		Nested WithInterface `json:"nested"`
+	}
+	var foo Foo
+	json.Marshal(foo)    // no error
+	json.Marshal(&foo)   // no error
+	json.Marshal(Foo{})  // no error
+	json.Marshal(&Foo{}) // no error
+}


### PR DESCRIPTION
Previously, only the top-level type was checked whether it implemented one of the provided interfaces. Nested types were not checked.

This leads to false positives, for example when one field is of a struct type implementing `json.Marshaller`.