### PR TITLE
feat: check whether structs within arrays/slices/maps implement a Marshaler interface

### DIFF
--- a/musttag.go
+++ b/musttag.go
@@ -166,7 +166,6 @@ func (c *checker) checkType(typ types.Type, tag string) bool {
 //
 // exits early if it hits a type that implements a whitelisted interface
 func (c *checker) parseStruct(typ types.Type) (*types.Struct, bool) {
-
 	if implementsInterface(typ, c.ifaceWhitelist, c.imports) {
 		return nil, false // the type implements a Marshaler interface; see issue #64.
 	}

--- a/testdata/src/tests/builtins.go
+++ b/testdata/src/tests/builtins.go
@@ -51,17 +51,6 @@ func testJSON() {
 	json.NewDecoder(nil).Decode(&tm)
 }
 
-func testJSONIndirectSlice() {
-	type WithMarshallableSlice struct {
-		List []Marshaler `json:"marshallable"`
-	}
-	var withMarshallableSlice WithMarshallableSlice
-
-	json.Marshal(withMarshallableSlice)
-	json.MarshalIndent(withMarshallableSlice, "", "")
-	json.NewEncoder(nil).Encode(withMarshallableSlice)
-}
-
 func testXML() {
 	var st Struct
 	xml.Marshal(st)                                             // want "the given struct should be annotated with the `xml` tag"

--- a/testdata/src/tests/builtins.go
+++ b/testdata/src/tests/builtins.go
@@ -51,6 +51,17 @@ func testJSON() {
 	json.NewDecoder(nil).Decode(&tm)
 }
 
+func testJSONIndirectSlice() {
+	type WithMarshallableSlice struct {
+		List []Marshaler `json:"marshallable"`
+	}
+	var withMarshallableSlice WithMarshallableSlice
+
+	json.Marshal(withMarshallableSlice)
+	json.MarshalIndent(withMarshallableSlice, "", "")
+	json.NewEncoder(nil).Encode(withMarshallableSlice)
+}
+
 func testXML() {
 	var st Struct
 	xml.Marshal(st)                                             // want "the given struct should be annotated with the `xml` tag"

--- a/testdata/src/tests/tests.go
+++ b/testdata/src/tests/tests.go
@@ -164,3 +164,14 @@ func ignoredNestedType() {
 	json.Marshal(Foo{})  // no error
 	json.Marshal(&Foo{}) // no error
 }
+
+func interfaceSliceType() {
+	type WithMarshallableSlice struct {
+		List []Marshaler `json:"marshallable"`
+	}
+	var withMarshallableSlice WithMarshallableSlice
+
+	json.Marshal(withMarshallableSlice)
+	json.MarshalIndent(withMarshallableSlice, "", "")
+	json.NewEncoder(nil).Encode(withMarshallableSlice)
+}


### PR DESCRIPTION
The current implementation of interface checks only handles cases where the root type implements json.Marshal. If it does not, the type is "unpacked" to a raw struct type, which is then checked for json: tags.

This fails when the root type does not implement json.Unmarshal, but is a transparent container for a type that contains a json.Marshal; e.g. `[]MyType` or `map[string]MyType` where `MyType` implements `json.Marshal`.

