### PR TITLE
fix: do not abort check on ignored fields

### DIFF
--- a/musttag.go
+++ b/musttag.go
@@ -222,7 +222,7 @@ func (c *checker) checkStruct(styp *types.Struct, tag string) (valid bool) {
 
 		// Do not recurse into ignored fields.
 		if tagValue == "-" {
-			return true
+			continue
 		}
 
 		if valid := c.checkType(field.Type(), tag); !valid {

--- a/testdata/src/tests/tests.go
+++ b/testdata/src/tests/tests.go
@@ -165,6 +165,22 @@ func ignoredNestedType() {
 	json.Marshal(&Foo{}) // no error
 }
 
+func ignoredNestedTypeWithSubsequentNoTagField() {
+	type Nested struct {
+		NoTag string
+	}
+	type Foo struct {
+		Ignored  Nested `json:"-"`
+		Exported string `json:"exported"`
+		NoTag    string
+	}
+	var foo Foo
+	json.Marshal(foo)    // want "the given struct should be annotated with the `json` tag"
+	json.Marshal(&foo)   // want "the given struct should be annotated with the `json` tag"
+	json.Marshal(Foo{})  // want "the given struct should be annotated with the `json` tag"
+	json.Marshal(&Foo{}) // want "the given struct should be annotated with the `json` tag"
+}
+
 func interfaceSliceType() {
 	type WithMarshallableSlice struct {
 		List []Marshaler `json:"marshallable"`


### PR DESCRIPTION
```go
type Nested struct {
	NoTagA string
}

type Foo struct {
	Ignored Nested `json:"-"`
	NoTagB  string
}
```

Such a structure should report an error because `NoTagB` lacks the `json` tag. However, it currently does not, because the misplaced `return` instead of `continue` is made in the code, which skips the check of subsequent fields.