### PR TITLE
perf: use module information

### DIFF
--- a/musttag.go
+++ b/musttag.go
@@ -49,9 +49,15 @@ func New(funcs ...Func) *analysis.Analyzer {
 			merge(funcs)
 			merge(flagFuncs)
 
-			mainModule, err := getMainModule()
-			if err != nil {
-				return nil, err
+			var mainModule string
+			if pass.Module != nil {
+				mainModule = pass.Module.Path
+			} else {
+				var err error
+				mainModule, err = getMainModule()
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			return run(pass, mainModule, allFuncs)


### PR DESCRIPTION
Now the `pass` contains the module information.

This skips the need to use `go list` to get the module path.